### PR TITLE
Use the calculated value for organisations order, not cached.

### DIFF
--- a/jobs/24pullrequests.rb
+++ b/jobs/24pullrequests.rb
@@ -39,11 +39,13 @@ end
 
 SCHEDULER.every '5m', :first_in => 0 do |job|
   orgs = HTTParty.get('http://24pullrequests.com/organisations.json')
-  orgs = orgs.take(8).map do |org|
+  orgs = orgs.map { |org|
     count = org['users'].inject(0) do |memo, user|
       memo + user['pull_requests_count']
     end
     {label: org['login'], value: count }
-  end
+  }.sort { |a, b|
+    a['value'] <=> b['value']
+  }.take(8)
   send_event('top_pr_org_count', items: orgs)
 end


### PR DESCRIPTION
The image on #11 shows an unordered organizations list. This is because it's ordered by a cached value on the server. I figure this is a slightly more accurate way of displaying it.
