### PR TITLE
Fixes gridster error on remove countdown widget

### DIFF
--- a/widgets/countdown/countdown.coffee
+++ b/widgets/countdown/countdown.coffee
@@ -8,7 +8,10 @@ class Dashing.Countdown extends Dashing.Widget
     end_timestamp = Math.round( Date.parse($(@node).find(".more-info").html())/1000 )
     seconds_until_end = end_timestamp - current_timestamp
     if seconds_until_end < 3600
-      $(@node).parent().remove()
+      gridster = $('.gridster ul:first').data('gridster')
+      gridster.remove_from_gridmap($(@node).parent())
+      gridster.remove_widget($(@node).parent(), true)
+      $(@node).empty()
     else if seconds_until_end < 0
       @set('timeleft', "TIME UP!")
       for i in [0..100] by 1


### PR DESCRIPTION
Fixes bug on removing countdown widget when seconds_until_end < 3600

Console log errors:
```
application.js:17163 Uncaught TypeError: Cannot read property 'row' of undefined
application.js:15792 Uncaught TypeError: Cannot read property 'col' of undefined
```