### PR TITLE
Fix Gemfile.lock, add dockerfile for quick build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.4.2
+
+COPY . /code
+WORKDIR /code
+RUN apt-get update && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && bundle
+
+EXPOSE 3030
+CMD bundle exec dashing start

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       rack (>= 1.0, < 3)
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
-    sass (3.5.4)
+    sass (3.2.19)
     simple_oauth (0.3.1)
     sinatra (1.4.8)
       rack (~> 1.5)


### PR DESCRIPTION
I could not run the dashboard on my laptop, bundle return an error:
```
Downloading sass-3.5.4 revealed dependencies not in the API or the lockfile
(sass-listen (~> 4.0.0)).
Either installing with `--full-index` or running `bundle update sass` should fix
the problem.

In Gemfile:
  dashing was resolved to 1.3.7, which depends on
    sass
```

I updated the Gemfile.lock and I add a Dockerfile for running the dashboard locally.